### PR TITLE
Use consistent color scheme

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -48,14 +48,15 @@ Options:
 
 // -- process information structure.
 type procInfo struct {
-	proc    string
-	cmdline string
-	quit    bool
-	cmd     *exec.Cmd
-	port    uint
-	mu      sync.Mutex
-	cond    *sync.Cond
-	waitErr error
+	proc       string
+	cmdline    string
+	quit       bool
+	cmd        *exec.Cmd
+	port       uint
+	colorIndex int
+	mu         sync.Mutex
+	cond       *sync.Cond
+	waitErr    error
 }
 
 // process informations named with proc.
@@ -113,6 +114,7 @@ func readProcfile(cfg *config) error {
 		return err
 	}
 	procs = map[string]*procInfo{}
+	index := 0
 	for _, line := range strings.Split(string(content), "\n") {
 		tokens := strings.SplitN(line, ":", 2)
 		if len(tokens) != 2 || tokens[0][0] == '#' {
@@ -124,12 +126,16 @@ func readProcfile(cfg *config) error {
 				return "%" + s[1:] + "%"
 			})
 		}
-		p := &procInfo{proc: k, cmdline: v, port: cfg.BasePort}
+		p := &procInfo{proc: k, cmdline: v, port: cfg.BasePort, colorIndex: index}
 		p.cond = sync.NewCond(&p.mu)
 		procs[k] = p
 		cfg.BasePort += 100
 		if len(k) > maxProcNameLength {
 			maxProcNameLength = len(k)
+		}
+		index++
+		if index >= len(colors) {
+			index = 0
 		}
 	}
 	if len(procs) == 0 {

--- a/log.go
+++ b/log.go
@@ -28,8 +28,6 @@ var colors = []ct.Color{
 	ct.Blue,
 	ct.Red,
 }
-var ci int
-
 var mutex = new(sync.Mutex)
 
 // write any stored buffers, plus the given line, then empty out
@@ -98,14 +96,10 @@ func (l *clogger) Write(p []byte) (int, error) {
 }
 
 // create logger instance.
-func createLogger(proc string) *clogger {
+func createLogger(proc string, colorIndex int) *clogger {
 	mutex.Lock()
 	defer mutex.Unlock()
-	l := &clogger{idx: ci, proc: proc, writes: make(chan []byte), done: make(chan struct{}), timeout: 2 * time.Millisecond}
+	l := &clogger{idx: colorIndex, proc: proc, writes: make(chan []byte), done: make(chan struct{}), timeout: 2 * time.Millisecond}
 	go l.writeLines()
-	ci++
-	if ci >= len(colors) {
-		ci = 0
-	}
 	return l
 }

--- a/proc_posix.go
+++ b/proc_posix.go
@@ -11,33 +11,34 @@ import (
 
 // spawn command that specified as proc.
 func spawnProc(proc string) bool {
-	logger := createLogger(proc)
+	procObj := procs[proc]
+	logger := createLogger(proc, procObj.colorIndex)
 
 	cs := []string{"/bin/sh", "-c", procs[proc].cmdline}
 	cmd := exec.Command(cs[0], cs[1:]...)
 	cmd.Stdin = nil
 	cmd.Stdout = logger
 	cmd.Stderr = logger
-	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", procs[proc].port))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", procObj.port))
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	fmt.Fprintf(logger, "Starting %s on port %d\n", proc, procs[proc].port)
+	fmt.Fprintf(logger, "Starting %s on port %d\n", proc, procObj.port)
 	err := cmd.Start()
 	if err != nil {
 		fmt.Fprintf(logger, "Failed to start %s: %s\n", proc, err)
 		return true
 	}
-	procs[proc].cmd = cmd
-	procs[proc].quit = true
-	procs[proc].mu.Unlock()
+	procObj.cmd = cmd
+	procObj.quit = true
+	procObj.mu.Unlock()
 	err = cmd.Wait()
-	procs[proc].mu.Lock()
-	procs[proc].cond.Broadcast()
-	procs[proc].waitErr = err
-	procs[proc].cmd = nil
+	procObj.mu.Lock()
+	procObj.cond.Broadcast()
+	procObj.waitErr = err
+	procObj.cmd = nil
 	fmt.Fprintf(logger, "Terminating %s\n", proc)
 
-	return procs[proc].quit
+	return procObj.quit
 }
 
 func terminateProc(proc string, signal os.Signal) error {

--- a/proc_windows.go
+++ b/proc_windows.go
@@ -9,9 +9,10 @@ import (
 
 // spawn command that specified as proc.
 func spawnProc(proc string) bool {
-	logger := createLogger(proc)
+	procObj := procs[proc]
+	logger := createLogger(proc, procObj.colorIndex)
 
-	cs := []string{"cmd", "/c", procs[proc].cmdline}
+	cs := []string{"cmd", "/c", procObj.cmdline}
 	cmd := exec.Command(cs[0], cs[1:]...)
 	cmd.Stdin = nil
 	cmd.Stdout = logger
@@ -19,22 +20,22 @@ func spawnProc(proc string) bool {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_UNICODE_ENVIRONMENT | 0x00000200,
 	}
-	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", procs[proc].port))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", procObj.port))
 
-	fmt.Fprintf(logger, "Starting %s on port %d\n", proc, procs[proc].port)
+	fmt.Fprintf(logger, "Starting %s on port %d\n", proc, procObj.port)
 	err := cmd.Start()
 	if err != nil {
 		fmt.Fprintf(logger, "Failed to start %s: %s\n", proc, err)
 		return true
 	}
-	procs[proc].cmd = cmd
-	procs[proc].quit = true
-	procs[proc].mu.Unlock()
+	procObj.cmd = cmd
+	procObj.quit = true
+	procObj.mu.Unlock()
 	err = cmd.Wait()
-	procs[proc].mu.Lock()
-	procs[proc].cond.Broadcast()
-	procs[proc].waitErr = err
-	procs[proc].cmd = nil
+	procObj.mu.Lock()
+	procObj.cond.Broadcast()
+	procObj.waitErr = err
+	procObj.cmd = nil
 	fmt.Fprintf(logger, "Terminating %s\n", proc)
 
 	return procs[proc].quit


### PR DESCRIPTION
Assign colors to the different processes in the order in which they
are defined in the Procfile. This means that the same process will
have the same color on every goreman run, and help associate logs to
colors in the file.