### PR TITLE
Kill entire process group when killing process

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -39,7 +39,7 @@ func stopProc(proc string, quit bool, signal os.Signal) error {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		if p, ok := procs[proc]; ok && p.cmd != nil {
-			err = p.cmd.Process.Kill()
+			err = killProc(p.cmd.Process)
 		}
 	})
 	p.cond.Wait()

--- a/proc_posix.go
+++ b/proc_posix.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // spawn command that specified as proc.
@@ -63,4 +65,9 @@ func terminateProc(proc string, signal os.Signal) error {
 		return err
 	}
 	return target.Signal(signal)
+}
+
+// killProc kills the proc with pid pid, as well as its children.
+func killProc(process *os.Process) error {
+	return unix.Kill(-1*process.Pid, syscall.SIGKILL)
 }

--- a/proc_windows.go
+++ b/proc_windows.go
@@ -68,3 +68,7 @@ func terminateProc(proc string, signal os.Signal) error {
 	}
 	return nil
 }
+
+func killProc(process *os.Process) error {
+	return process.Kill()
+}


### PR DESCRIPTION
Previously when we would send a Kill command to a subprocess, we would
not send that same command to processes started by the subprocess (the
grandchildren, if you will). This resulted in goreman hanging when you
send a ctrl+C to it.

Sending -1*pid in the syscall tells Unix to kill the entire process
group - the child and the grandchildren, not just the child.

Verified that this fixes the hang I observed when running
dev/launch.sh manually.

For more, see
https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773.
I am not sure there is a Windows analog so for that we continue to use
cmd.Process.Kill().