### PR TITLE
log which proc failed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	golang.org/x/sys v0.0.0-20180925112736-b09afc3d579e
 	gopkg.in/yaml.v2 v2.2.1
 )
+
+go 1.13


### PR DESCRIPTION
In case failed proc has its logs redirected or they are not visible for some other reason, at least print to stdout which proc failed so appropriate investigation can start at the right proc.